### PR TITLE
Update AWS SAM CLI to 1.150.1 to support Node.js 22.x runtime

### DIFF
--- a/aws-sam-build/docker/Dockerfile
+++ b/aws-sam-build/docker/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /app
 RUN apk get update && \
     apk add --no-cache bash python3 py3-pip
 
-RUN pip install aws-sam-cli --break-system-packages
+RUN pip install aws-sam-cli==1.150.1 --break-system-packages
 ADD aws-sam-build/release/linux/amd64/plugin /bin/
 
 

--- a/aws-sam-build/docker/Dockerfile.linux.arm64
+++ b/aws-sam-build/docker/Dockerfile.linux.arm64
@@ -6,7 +6,7 @@ RUN apk get update && \
     apk add --no-cache bash python3 py3-pip gcc \
     python3-dev libffi-dev musl-dev
 
-RUN pip install aws-sam-cli --break-system-packages
+RUN pip install aws-sam-cli==1.150.1 --break-system-packages
 ADD aws-sam-build/release/linux/arm64/plugin /bin/
 
 ENTRYPOINT ["/bin/plugin"]


### PR DESCRIPTION
Updates AWS SAM CLI version from unpinned to 1.150.1 in Docker images to support Node.js 22.x runtime builds.